### PR TITLE
feat: replaced AppTheme to the ComposeFragment so the theme will be u…

### DIFF
--- a/app/src/main/java/com/monstarlab/core/ui/ComposeFragment.kt
+++ b/app/src/main/java/com/monstarlab/core/ui/ComposeFragment.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.Fragment
+import com.monstarlab.designsystem.theme.AppTheme
 
 abstract class ComposeFragment : Fragment() {
 
@@ -21,7 +22,9 @@ abstract class ComposeFragment : Fragment() {
         return ComposeView(requireContext()).apply {
             setContent {
                 setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-                content.invoke()
+                AppTheme {
+                    content.invoke()
+                }
             }
         }
     }

--- a/app/src/main/java/com/monstarlab/features/login/ui/LoginRoute.kt
+++ b/app/src/main/java/com/monstarlab/features/login/ui/LoginRoute.kt
@@ -8,7 +8,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.monstarlab.core.ui.effects.SystemUISideEffect
-import com.monstarlab.designsystem.theme.AppTheme
 
 @OptIn(ExperimentalLifecycleComposeApi::class)
 @Composable
@@ -27,9 +26,7 @@ fun LoginRoute(
     val actions = rememberLoginActions(coordinator)
 
     // UI Rendering
-    AppTheme {
-        LoginScreen(uiState, actions)
-    }
+    LoginScreen(uiState, actions)
 }
 
 @Composable


### PR DESCRIPTION
…sed in whole app

**Acceptance criteria:**  
- [ ] PR title includes Jira ticket reference
- [ ] Follows UI patterns from [UI manifesto](https://github.com/monstar-lab-oss/ui-manifesto)
- [ ] Loading/error/empty states taken into account
- [ ] Status of Jira ticket updated
- [ ] Removed commented out code  
- [ ] Removed unnecessary logging
- [ ] Tested flows in airplane mode and bad connection
- [ ] Updated documentation (please add a link if other than README 😊)

**Related to other PRs:**  

**Notes for reviewers:**  
Currently, the template uses the AppTheme separately in each class, but we could put it in a compose fragment so that the theme applies to the entire application.