### PR TITLE
Added LeakCanary + Chucker + Network Config

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -89,6 +89,12 @@ kapt {
 
 configurations {
     create("devDebugImplementation")
+    create("stagingDebugImplementation")
+}
+
+private var isStagingDebug = false
+gradle.startParameter.taskNames.forEach { task ->
+    isStagingDebug = task.contains("StagingDebug", true)
 }
 
 dependencies {
@@ -143,5 +149,6 @@ dependencies {
     implementation(Libs.nstack)
     implementation(Libs.timber)
     "devDebugImplementation"(Libs.leakCanary)
+    implementation(if (isStagingDebug) Libs.chuckerDebug else Libs.chucker)
 
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -80,7 +80,11 @@ android {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
     }
-    kotlinOptions.jvmTarget = JavaVersion.VERSION_11.toString()
+    kotlin {
+        jvmToolchain {
+            languageVersion.set(JavaLanguageVersion.of(JavaVersion.VERSION_11.toString()))
+        }
+    }
 }
 
 kapt {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -89,12 +89,6 @@ kapt {
 
 configurations {
     create("devDebugImplementation")
-    create("stagingDebugImplementation")
-}
-
-private var isStagingDebug = false
-gradle.startParameter.taskNames.forEach { task ->
-    isStagingDebug = task.contains("StagingDebug", true)
 }
 
 dependencies {
@@ -149,6 +143,7 @@ dependencies {
     implementation(Libs.nstack)
     implementation(Libs.timber)
     "devDebugImplementation"(Libs.leakCanary)
-    implementation(if (isStagingDebug) Libs.chuckerDebug else Libs.chucker)
+    releaseImplementation(Libs.chuckerNoOp)
+    debugImplementation(Libs.chuckerDebug)
 
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,7 +39,6 @@ android {
             )
         }
     }
-
     productFlavors {
         create("dev") {
             dimension = "default"
@@ -88,6 +87,10 @@ kapt {
     correctErrorTypes = true
 }
 
+configurations {
+    create("devDebugImplementation")
+}
+
 dependencies {
 
     implementation(Libs.Kotlin.stdlib)
@@ -125,7 +128,6 @@ dependencies {
     implementation(Libs.Android.Lifecycle.livedata)
     implementation(Libs.Android.Lifecycle.runtimeCompose)
 
-
     implementation(platform(Libs.Compose.bom))
     implementation(Libs.Compose.material)
     implementation(Libs.Compose.preview)
@@ -140,5 +142,6 @@ dependencies {
 
     implementation(Libs.nstack)
     implementation(Libs.timber)
+    "devDebugImplementation"(Libs.leakCanary)
 
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     package="com.monstarlab">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:name=".App"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,12 +12,13 @@
         android:fullBackupOnly="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Androidtemplate">
         <activity
-          android:name=".features.main.MainActivity"
-          android:exported="true">
+            android:name=".features.main.MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/monstarlab/core/network/OkHttpModule.kt
+++ b/app/src/main/java/com/monstarlab/core/network/OkHttpModule.kt
@@ -1,11 +1,14 @@
 package com.monstarlab.core.network
 
+import android.content.Context
+import com.chuckerteam.chucker.api.ChuckerInterceptor
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import com.monstarlab.BuildConfig
 import com.monstarlab.core.network.errorhandling.ApiErrorInterceptor
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
@@ -22,20 +25,18 @@ class OkHttpModule {
 
     @Provides
     @Singleton
-    fun provideHttpClient(): OkHttpClient {
+    fun provideHttpClient(@ApplicationContext context: Context): OkHttpClient {
         val clientBuilder = OkHttpClient.Builder()
             .connectTimeout(45, TimeUnit.SECONDS)
             .readTimeout(60, TimeUnit.SECONDS)
             .writeTimeout(60, TimeUnit.SECONDS)
-
         if (BuildConfig.DEBUG) {
             val logging = HttpLoggingInterceptor()
             logging.level = HttpLoggingInterceptor.Level.BODY
             clientBuilder.addInterceptor(logging)
         }
-
+        clientBuilder.addInterceptor(ChuckerInterceptor.Builder(context).build())
         clientBuilder.addInterceptor(ApiErrorInterceptor(json))
-
         return clientBuilder.build()
     }
 

--- a/app/src/main/java/com/monstarlab/features/main/MainActivity.kt
+++ b/app/src/main/java/com/monstarlab/features/main/MainActivity.kt
@@ -1,16 +1,33 @@
 package com.monstarlab.features.main
 
+import android.os.Build
 import android.os.Bundle
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.WindowCompat
+import com.chuckerteam.chucker.api.Chucker
 import com.monstarlab.R
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity(R.layout.activity_main) {
+
+    private val notificationRequest =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         WindowCompat.setDecorFitsSystemWindows(window, false)
         setupNStack()
+        checkNotificationPermission()
     }
+
+    private fun checkNotificationPermission() {
+        // If the app send notifications other than Chucker's, remove the `isOp` check and move
+        // the request to the appropriate screen in the app
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && Chucker.isOp) {
+            notificationRequest.launch(android.Manifest.permission.POST_NOTIFICATIONS)
+        }
+    }
+
 }

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,8 @@
+<network-security-config>
+    <debug-overrides>
+        <trust-anchors>
+            <!-- Trust user added CAs while debuggable only -->
+            <certificates src="user" />
+        </trust-anchors>
+    </debug-overrides>
+</network-security-config>

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -3,6 +3,7 @@
         <trust-anchors>
             <!-- Trust user added CAs while debuggable only -->
             <certificates src="user" />
+            <certificates src="system" />
         </trust-anchors>
     </debug-overrides>
 </network-security-config>

--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -26,8 +26,8 @@ object Libs {
         val ktxCore = "1.9.0"
         val material = "1.8.0"
         val navigation = "2.5.3"
-        val chucker = "3.3.0"
-        val leakCanary = "2.5"
+        val chucker = "3.5.2"
+        val leakCanary = "2.10"
         val desugaring = "1.0.9"
         val nstackGradlePlugin = "3.2.5"
         val datastore = "1.0.0"
@@ -102,5 +102,7 @@ object Libs {
     val nstack = "dk.nodes.nstack:nstack-kotlin:${Versions.nstack}"
     val timber = "com.jakewharton.timber:timber:${Versions.timber}"
     val leakCanary = "com.squareup.leakcanary:leakcanary-android:${Versions.leakCanary}"
+    val chucker = "com.github.chuckerteam.chucker:library-no-op:${Versions.chucker}"
+    val chuckerDebug = "com.github.chuckerteam.chucker:library:${Versions.chucker}"
 
 }

--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -102,7 +102,7 @@ object Libs {
     val nstack = "dk.nodes.nstack:nstack-kotlin:${Versions.nstack}"
     val timber = "com.jakewharton.timber:timber:${Versions.timber}"
     val leakCanary = "com.squareup.leakcanary:leakcanary-android:${Versions.leakCanary}"
-    val chucker = "com.github.chuckerteam.chucker:library-no-op:${Versions.chucker}"
+    val chuckerNoOp = "com.github.chuckerteam.chucker:library-no-op:${Versions.chucker}"
     val chuckerDebug = "com.github.chuckerteam.chucker:library:${Versions.chucker}"
 
 }

--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -101,5 +101,6 @@ object Libs {
 
     val nstack = "dk.nodes.nstack:nstack-kotlin:${Versions.nstack}"
     val timber = "com.jakewharton.timber:timber:${Versions.timber}"
+    val leakCanary = "com.squareup.leakcanary:leakcanary-android:${Versions.leakCanary}"
 
 }


### PR DESCRIPTION
We used to have LeakCanary and Chucker but for some reason, they are gone. This PR adds them back as follows:
- `devDebug` builds: have LeakCanary so as devs are working on the app they can spot sooner when if something is leaking when they run the app
- `stagingDebug` builds: have Chucker, so QA can have access to network logs without requiring to have Charles
- `release`: should have none of these

I also added the network config file to support Charles in debug build. This should close #13.