### PR TITLE
fix: Renamed SingleDataSource to just DataSource as base-class

### DIFF
--- a/app/src/main/java/com/monstarlab/core/persistence/DataSource.kt
+++ b/app/src/main/java/com/monstarlab/core/persistence/DataSource.kt
@@ -1,8 +1,7 @@
 package com.monstarlab.core.persistence
 
 interface DataSource<T> {
-    suspend fun getAll(): List<T>
-    suspend fun add(item: T)
-    suspend fun addAll(items: List<T>)
+    suspend fun load(): T?
+    suspend fun save(item: T)
     suspend fun clear()
 }

--- a/app/src/main/java/com/monstarlab/core/persistence/ListDataSource.kt
+++ b/app/src/main/java/com/monstarlab/core/persistence/ListDataSource.kt
@@ -1,0 +1,6 @@
+package com.monstarlab.core.persistence
+
+interface ListDataSource<T> : DataSource<List<T>> {
+    override suspend fun save(items: List<T>)
+    suspend fun add(item: T)
+}

--- a/app/src/main/java/com/monstarlab/core/persistence/SingleDataSource.kt
+++ b/app/src/main/java/com/monstarlab/core/persistence/SingleDataSource.kt
@@ -1,7 +1,0 @@
-package com.monstarlab.core.persistence
-
-interface SingleDataSource<T> {
-    suspend fun get(): T?
-    suspend fun add(item: T)
-    suspend fun clear()
-}

--- a/app/src/main/java/com/monstarlab/features/resources/data/persistence/ResourcesPreferenceStore.kt
+++ b/app/src/main/java/com/monstarlab/features/resources/data/persistence/ResourcesPreferenceStore.kt
@@ -2,10 +2,10 @@ package com.monstarlab.features.resources.data.persistence
 
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
-import com.monstarlab.core.persistence.SharedPreferenceDataStore
+import com.monstarlab.core.persistence.ListPreferenceDataStore
 import com.monstarlab.features.resources.domain.model.Resource
 import javax.inject.Inject
 
-class ResourcePreferenceStore @Inject constructor(
+class ResourcesPreferenceStore @Inject constructor(
     dataStore: DataStore<Preferences>,
-) : SharedPreferenceDataStore<Resource>(dataStore, Resource.serializer())
+) : ListPreferenceDataStore<Resource>(dataStore, Resource.serializer())

--- a/app/src/main/java/com/monstarlab/features/resources/data/repository/ResourceRepositoryImpl.kt
+++ b/app/src/main/java/com/monstarlab/features/resources/data/repository/ResourceRepositoryImpl.kt
@@ -2,19 +2,19 @@ package com.monstarlab.features.resources.data.repository
 
 import com.monstarlab.features.resources.data.api.ResourcesApi
 import com.monstarlab.features.resources.data.api.dtos.toResource
-import com.monstarlab.features.resources.data.persistence.ResourcePreferenceStore
+import com.monstarlab.features.resources.data.persistence.ResourcesPreferenceStore
 import com.monstarlab.features.resources.domain.model.Resource
 import com.monstarlab.features.resources.domain.repository.ResourceRepository
 import javax.inject.Inject
 
 class ResourceRepositoryImpl @Inject constructor(
     private val api: ResourcesApi,
-    private val resourcePreferenceStore: ResourcePreferenceStore,
+    private val resourcesPreferenceStore: ResourcesPreferenceStore,
 ) : ResourceRepository {
 
     override suspend fun get(): List<Resource> {
         return api.getResources().data.map { it.toResource() }.also {
-            resourcePreferenceStore.addAll(it)
+            resourcesPreferenceStore.save(it)
         }
     }
 }

--- a/app/src/main/java/com/monstarlab/features/user/data/persistence/UserPreferenceStore.kt
+++ b/app/src/main/java/com/monstarlab/features/user/data/persistence/UserPreferenceStore.kt
@@ -2,10 +2,10 @@ package com.monstarlab.features.user.data.persistence
 
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
-import com.monstarlab.core.persistence.SingleSharedPreferenceDataStore
+import com.monstarlab.core.persistence.SinglePreferenceDataStore
 import com.monstarlab.features.user.domain.model.User
 import javax.inject.Inject
 
 class UserPreferenceStore @Inject constructor(
     dataStore: DataStore<Preferences>,
-) : SingleSharedPreferenceDataStore<User>(dataStore, User.serializer())
+) : SinglePreferenceDataStore<User>(dataStore, User.serializer())

--- a/app/src/main/java/com/monstarlab/features/user/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/monstarlab/features/user/data/repository/UserRepositoryImpl.kt
@@ -14,7 +14,7 @@ class UserRepositoryImpl @Inject constructor(
 
     override suspend fun get(): User {
         return api.getUser().data.toUser().also {
-            userPreferenceStore.add(it)
+            userPreferenceStore.save(it)
         }
     }
 }


### PR DESCRIPTION
Consistency in name and function.

fix: Renamed DataSource.kt to ListDataSource, because that's what it is. Also made it inherit from DataSource.
fix: Removed "shared" in the naming, because that might confuse these with using actual SharedPreferences.
fix: Renamed the member-functions from get/add/getAll/addAll to load/save/add, and made the behavior consistent between list- and single-.
fix: Simplified add().
fix: Better clear() - actually remove stuff, not just overwrite with empty string.
feat: Added Javadoc, even though the naming should be quite self-explanatory