### PR TITLE
Upgrade klint to 1.0.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,7 @@ subprojects {
         kotlin {
             target("**/*.kt")
             targetExclude("**/RateReminderActions.kt")
-            ktlint("0.40.0")
+            ktlint("1.0.0")
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,7 @@ subprojects {
         kotlin {
             target("**/*.kt")
             targetExclude("**/RateReminderActions.kt")
-            ktlint("1.0.0")
+            ktlint("0.50.0")
         }
     }
 }


### PR DESCRIPTION
Klint was used as version 0.40.0 - that causes all spotless checks to fail for new PRs. version 1.0.0 is available, so i've set spotless to use that https://github.com/pinterest/ktlint/releases 
